### PR TITLE
Add AWS SDK + secret manager support to Hive.

### DIFF
--- a/endpoints/Server/Controllers/HelloController.cs
+++ b/endpoints/Server/Controllers/HelloController.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+using Amazon.SecretsManager;
+using Hive.Endpoints.Server.Extensions;
+using Hive.Endpoints.Server.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Hive.Endpoints.Server.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class HelloController : ControllerBase
+    {
+        private readonly ILogger<HelloController> _logger;
+        private readonly IAmazonSecretsManager _secrets;
+
+        public HelloController(ILogger<HelloController> logger, IAmazonSecretsManager secrets)
+        {
+            _logger = logger;
+            _secrets = secrets;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var result = await _secrets.GetValue<TestSecret>("test_secret");
+
+            _logger?.LogWarning($"Fetched secret: {result.Hello}");
+
+            return Content("Successful.");
+        }
+    }
+}

--- a/endpoints/Server/Extensions/AmazonSecretManagerExtensions.cs
+++ b/endpoints/Server/Extensions/AmazonSecretManagerExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+using Newtonsoft.Json;
+
+namespace Hive.Endpoints.Server.Extensions
+{
+    public static class AmazonSecretManagerExtensions
+    {
+        public static async Task<T> GetValue<T>(this IAmazonSecretsManager source, string secretName)
+        {
+            var request = new GetSecretValueRequest
+            {
+                SecretId = secretName
+            };
+
+            var result = await source.GetSecretValueAsync(request);
+            return JsonConvert.DeserializeObject<T>(result.SecretString);
+        }
+    }
+}

--- a/endpoints/Server/Hive.Endpoints.Server.csproj
+++ b/endpoints/Server/Hive.Endpoints.Server.csproj
@@ -11,7 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.32.0" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.0.36" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.38.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/endpoints/Server/Models/TestSecret.cs
+++ b/endpoints/Server/Models/TestSecret.cs
@@ -1,0 +1,7 @@
+﻿namespace Hive.Endpoints.Server.Models
+{
+    public class TestSecret
+    {
+        public string Hello { get; set; }
+    }
+}

--- a/endpoints/Server/Services/GreeterService.cs
+++ b/endpoints/Server/Services/GreeterService.cs
@@ -2,7 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Amazon.SecretsManager;
 using Grpc.Core;
+using Hive.Endpoints.Server.Extensions;
+using Hive.Endpoints.Server.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Hive.Endpoints.Server
@@ -10,6 +13,7 @@ namespace Hive.Endpoints.Server
     public class GreeterService : Greeter.GreeterBase
     {
         private readonly ILogger<GreeterService> _logger;
+
         public GreeterService(ILogger<GreeterService> logger)
         {
             _logger = logger;

--- a/endpoints/Server/Services/GreeterService.cs
+++ b/endpoints/Server/Services/GreeterService.cs
@@ -2,10 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.SecretsManager;
 using Grpc.Core;
-using Hive.Endpoints.Server.Extensions;
-using Hive.Endpoints.Server.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Hive.Endpoints.Server
@@ -13,7 +10,6 @@ namespace Hive.Endpoints.Server
     public class GreeterService : Greeter.GreeterBase
     {
         private readonly ILogger<GreeterService> _logger;
-
         public GreeterService(ILogger<GreeterService> logger)
         {
             _logger = logger;

--- a/endpoints/Server/Startup.cs
+++ b/endpoints/Server/Startup.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Amazon.SecretsManager;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -12,14 +14,23 @@ namespace Hive.Endpoints.Server
 {
     public class Startup
     {
-        // This method gets called by the runtime. Use this method to add services to the container.
-        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-        public void ConfigureServices(IServiceCollection services)
+        public Startup(IConfiguration config)
         {
-            services.AddGrpc();
+            Configuration = config;
         }
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+            services.AddGrpc();
+            services.AddLogging();
+
+            services.AddDefaultAWSOptions(Configuration.GetAWSOptions());
+            services.AddAWSService<IAmazonSecretsManager>();
+        }
+        
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
@@ -31,6 +42,7 @@ namespace Hive.Endpoints.Server
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapControllers();
                 endpoints.MapGrpcService<GreeterService>();
 
                 endpoints.MapGet("/", async context =>

--- a/endpoints/Server/appsettings.json
+++ b/endpoints/Server/appsettings.json
@@ -11,5 +11,8 @@
     "EndpointDefaults": {
       "Protocols": "Http2"
     }
-  }
+  },
+  "AWS": {
+    "Region": "us-east-2" 
+  } 
 }


### PR DESCRIPTION
Includes an example HTTP API controller (to test it since I did not have a gRPC client installed locally). 

The secrets manager relies upon your AWS CLI configuration, See [this link](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) for information on getting it installed and configured.